### PR TITLE
Use octicons to denote files/directories/symlinks instead of description.

### DIFF
--- a/src/advancedOpenFile.ts
+++ b/src/advancedOpenFile.ts
@@ -6,6 +6,12 @@ import * as fs from "fs"
 import * as mkdirp from "mkdirp"
 
 const pathSeparator = path.sep
+const icons = {
+  [FileType.File]: "$(file)",
+  [FileType.Directory]: "$(file-directory)",
+  [FileType.SymbolicLink]: "$(file-symlink-file)",
+  [FileType.Unknown]: "$(file)",
+}
 
 class FilePickItem implements QuickPickItem {
   relativePath: string
@@ -18,11 +24,8 @@ class FilePickItem implements QuickPickItem {
   constructor(relativePath: string, absolutePath: string, filetype: FileType) {
     this.relativePath = relativePath
     this.absolutePath = absolutePath
-    this.label = this.relativePath
+    this.label = `${icons[filetype]} ${this.relativePath}`
     this.filetype = filetype
-    if (filetype === FileType.Directory) {
-      this.description = "Directory"
-    }
   }
 }
 
@@ -109,7 +112,7 @@ async function pickFile(
     } else if (pickedItem instanceof FilePickItem) {
       if (pickedItem.filetype === FileType.Directory) {
         const items = await createFilePickItems(rootPath, pickedItem.relativePath)
-        return pickFile(pickedItem.label + pathSeparator, rootPath, items)
+        return pickFile(pickedItem.relativePath + pathSeparator, rootPath, items)
       } else {
         return pickedItem
       }


### PR DESCRIPTION
First of all, thanks for making a VSCode port! I had briefly tried making one myself a year or so ago and didn't really make much progress. Not having an equivalent to advanced-open-file in VSCode is one of the main reasons I still use Atom as my main editor.

Apparently you can insert icons into text labels, which seemed like a better way to denote files vs directories than the description field. Let me know what you think!