### PR TITLE
Add selectPath config to enable/disable path selection when opening

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "configuration": {
             "title": "VscodeAdvancedOpenFile Configuration",
             "properties": {
-              "VscodeAdvancedOpenFile.selectPath": {
+              "vscode-advanced-open-file.selectPath": {
                 "type": "boolean",
                 "default": true,
                 "description": "Select the path when QuickPick opens"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,13 @@
         ],
         "configuration": {
             "title": "VscodeAdvancedOpenFile Configuration",
-            "properties": {}
+            "properties": {
+              "VscodeAdvancedOpenFile.selectPath": {
+                "type": "boolean",
+                "default": true,
+                "description": "Select the path when QuickPick opens"
+              }
+            }
         }
     },
     "scripts": {

--- a/src/advancedOpenFile.ts
+++ b/src/advancedOpenFile.ts
@@ -188,7 +188,7 @@ async function openFile(path: string): Promise<void> {
 }
 
 export async function advancedOpenFile() {
-  const selectValue: boolean = workspace.getConfiguration().get("VscodeAdvancedOpenFile.selectPath")
+  const selectValue: boolean = workspace.getConfiguration().get("vscode-advanced-open-file.selectPath")
 
   const currentEditor = window.activeTextEditor
   let targetWorkspaceFolder: WorkspaceFolder

--- a/src/advancedOpenFile.ts
+++ b/src/advancedOpenFile.ts
@@ -77,21 +77,36 @@ function createFilePickItems(value: string): Promise<ReadonlyArray<QuickPickItem
   })
 }
 
-function createFilePicker(value: string, items: ReadonlyArray<QuickPickItem>): QuickPick<QuickPickItem> {
+function createFilePicker(
+  value: string,
+  items: ReadonlyArray<QuickPickItem>,
+  selectValue: boolean
+): QuickPick<QuickPickItem> {
   const quickpick = window.createQuickPick()
-  quickpick.value = value
   quickpick.items = items
   quickpick.placeholder = "select file"
+
+  if (selectValue) {
+    quickpick.value = value
+  }
 
   return quickpick
 }
 
-async function pickFile(value: string, items: ReadonlyArray<QuickPickItem>): Promise<QuickPickItem | string> {
-  const quickpick = createFilePicker(value, items)
+async function pickFile(
+  value: string,
+  items: ReadonlyArray<QuickPickItem>,
+  selectValue: boolean
+): Promise<QuickPickItem | string> {
+  const quickpick = createFilePicker(value, items, selectValue)
   const disposables: Disposable[] = []
 
   try {
     quickpick.show()
+
+    if (!selectValue) {
+      quickpick.value = value
+    }
 
     const pickedItem = await new Promise<QuickPickItem | string>(resolve => {
       disposables.push(
@@ -121,7 +136,7 @@ async function pickFile(value: string, items: ReadonlyArray<QuickPickItem>): Pro
       if (pickedItem.filetype === FileType.Directory) {
         const directory = pickedItem.absolutePath + (pickedItem.absolutePath === fsRoot ? "" : pathSeparator)
         const items = await createFilePickItems(directory)
-        return pickFile(directory, items)
+        return pickFile(directory, items, selectValue)
       } else {
         return pickedItem
       }
@@ -173,6 +188,8 @@ async function openFile(path: string): Promise<void> {
 }
 
 export async function advancedOpenFile() {
+  const selectValue: boolean = workspace.getConfiguration().get("VscodeAdvancedOpenFile.selectPath")
+
   const currentEditor = window.activeTextEditor
   let targetWorkspaceFolder: WorkspaceFolder
   let defaultDir: string
@@ -186,7 +203,7 @@ export async function advancedOpenFile() {
   defaultDir += pathSeparator
 
   const filePickItems = await createFilePickItems(defaultDir)
-  const pickedItem = await pickFile(defaultDir, filePickItems)
+  const pickedItem = await pickFile(defaultDir, filePickItems, selectValue)
 
   if (!pickedItem) {
     throw new Error("failed")


### PR DESCRIPTION
Hi,

as Osmose described the path selection in the filter box in https://github.com/jit-y/vscode-advanced-open-file/issues/6. I also think it's very useful if path is not selected. I added a configuration parameter to toggle the behavior.

Add the following line to your settings.json to disable path selection when opening.

```"VscodeAdvancedOpenFile.selectPath": false,```

I've found a workaround for QuickPick not to select the path: If you set the value of QuickPick instance (`quickPick.value = "/path")` after you call `quickPick.show`, you can bypass the block that select the path.

https://github.com/microsoft/vscode/blob/c2dcd0ba67feecaca49bbc49ebba9728c5cd1722/src/vs/workbench/browser/parts/quickinput/quickInput.ts#L702