### PR TITLE
Add an option to group directories above files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ This extension is based on [advanced-open-file](https://github.com/Osmose/advanc
 ## Settings
 ### `vscode-advanced-open-file.selectPath`
 
-If you set `true`, it is enabled path selection on opening filter box. (Default: `false`)
+If set to `true`, when the picker is opened, the entire path will be selected (i.e. typing immediately will replace the path instead of adding to it). (Default: `false`)
+
+### `vscode-advanced-open-file.groupDirectoriesFirst`
+
+If set to `true`, directories will be grouped before files. (Default: `false`)
 
 ## LICENSE
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Select the path when QuickPick opens"
+                },
+                "vscode-advanced-open-file.groupDirectoriesFirst": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Group directories before files"
                 }
             }
         }

--- a/src/advancedOpenFile.ts
+++ b/src/advancedOpenFile.ts
@@ -62,6 +62,19 @@ async function createFilePickItems(value: string): Promise<ReadonlyArray<QuickPi
       })
     );
 
+    // Group directories first if desired
+    if (workspace.getConfiguration().get("vscode-advanced-open-file.groupDirectoriesFirst")) {
+      filePickItems.sort((fileA, fileB) => {
+        if (fileA.filetype === FileType.Directory && fileB.filetype !== FileType.Directory) {
+          return -1;
+        } else if (fileA.filetype !== FileType.Directory && fileB.filetype === FileType.Directory) {
+          return 1;
+        }
+
+        return 0;
+      });
+    }
+
     if (!fragment && directory !== fsRoot) {
       const parent = path.dirname(directory);
       filePickItems.unshift(new FilePickItem(parent, FileType.Directory, ".."));


### PR DESCRIPTION
The original advanced-open-file sorted directories and files separately and put directories first, which is my preference, so I added it back in here with a config option (defaulting to off, up to you what you want default behavior to be).

Thanks as always!

![Screen Shot 2019-12-22 at 1 51 53 AM](https://user-images.githubusercontent.com/193106/71320262-a6f73a00-245d-11ea-9bf0-e69a3f402e12.png)
