### PR TITLE
Add command to open file relative to active workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:extension.advancedOpenFile"
+        "onCommand:extension.advancedOpenFile",
+        "onCommand:extension.advancedOpenWorkspaceFile"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
         "commands": [
             {
                 "command": "extension.advancedOpenFile",
-                "title": "Advanced Open File"
+                "title": "Advanced Open File: from active directory"
+            },
+            {
+                "command": "extension.advancedOpenWorkspaceFile",
+                "title": "Advanced Open File: from active workspace"
             }
         ],
         "keybindings": [

--- a/src/advancedOpenFile.ts
+++ b/src/advancedOpenFile.ts
@@ -102,10 +102,7 @@ function createFilePicker(
   return quickpick;
 }
 
-async function pickFile(
-  value: string,
-  items: ReadonlyArray<QuickPickItem>
-): Promise<QuickPickItem | string> {
+async function pickFile(value: string, items: ReadonlyArray<QuickPickItem>): Promise<QuickPickItem | string> {
   const selectValue: boolean = workspace.getConfiguration().get("vscode-advanced-open-file.selectPath");
   const quickpick = createFilePicker(value, items, selectValue);
   const disposables: Disposable[] = [];
@@ -252,7 +249,7 @@ async function pathToCurrentWorkspace(): Promise<string> {
 }
 
 export async function advancedOpenFile() {
-  advancedOpen(await pathToCurrentDirectory())
+  advancedOpen(await pathToCurrentDirectory());
 }
 
 export async function advancedOpenWorkspaceFile() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,9 @@ import { advancedOpenFile, advancedOpenWorkspaceFile } from "./advancedOpenFile"
 
 export function activate(context: ExtensionContext) {
   context.subscriptions.push(commands.registerCommand("extension.advancedOpenFile", advancedOpenFile));
-  context.subscriptions.push(commands.registerCommand("extension.advancedOpenWorkspaceFile", advancedOpenWorkspaceFile));
+  context.subscriptions.push(
+    commands.registerCommand("extension.advancedOpenWorkspaceFile", advancedOpenWorkspaceFile)
+  );
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,10 +2,11 @@
 
 import { commands, ExtensionContext } from "vscode";
 
-import { advancedOpenFile } from "./advancedOpenFile";
+import { advancedOpenFile, advancedOpenWorkspaceFile } from "./advancedOpenFile";
 
 export function activate(context: ExtensionContext) {
   context.subscriptions.push(commands.registerCommand("extension.advancedOpenFile", advancedOpenFile));
+  context.subscriptions.push(commands.registerCommand("extension.advancedOpenWorkspaceFile", advancedOpenWorkspaceFile));
 }
 
 export function deactivate() {}


### PR DESCRIPTION
This PR adds a second command (no default key binding) that starts the file picker at the root of the current workspace rather than the directory of the current file.