### PR TITLE
Delete vscode-advanced-open-file.selectPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ This extension is based on [advanced-open-file](https://github.com/Osmose/advanc
 - Creating a new file if there is no file on typed relative path.
 
 ## Settings
-### `vscode-advanced-open-file.selectPath`
-
-If set to `true`, when the picker is opened, the entire path will be selected (i.e. typing immediately will replace the path instead of adding to it). (Default: `false`)
-
 ### `vscode-advanced-open-file.groupDirectoriesFirst`
 
 If set to `true`, directories will be grouped before files. (Default: `false`)

--- a/package.json
+++ b/package.json
@@ -39,11 +39,6 @@
         "configuration": {
             "title": "VscodeAdvancedOpenFile Configuration",
             "properties": {
-                "vscode-advanced-open-file.selectPath": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Select the path when QuickPick opens"
-                },
                 "vscode-advanced-open-file.groupDirectoriesFirst": {
                     "type": "boolean",
                     "default": false,

--- a/src/advancedOpenFile.ts
+++ b/src/advancedOpenFile.ts
@@ -86,33 +86,22 @@ async function createFilePickItems(value: string): Promise<ReadonlyArray<QuickPi
   }
 }
 
-function createFilePicker(
-  value: string,
-  items: ReadonlyArray<QuickPickItem>,
-  selectValue: boolean
-): QuickPick<QuickPickItem> {
+function createFilePicker(value: string, items: ReadonlyArray<QuickPickItem>): QuickPick<QuickPickItem> {
   const quickpick = window.createQuickPick();
   quickpick.items = items;
   quickpick.placeholder = "select file";
-
-  if (selectValue) {
-    quickpick.value = value;
-  }
 
   return quickpick;
 }
 
 async function pickFile(value: string, items: ReadonlyArray<QuickPickItem>): Promise<QuickPickItem | string> {
-  const selectValue: boolean = workspace.getConfiguration().get("vscode-advanced-open-file.selectPath");
-  const quickpick = createFilePicker(value, items, selectValue);
+  const quickpick = createFilePicker(value, items);
   const disposables: Disposable[] = [];
 
   try {
     quickpick.show();
 
-    if (!selectValue) {
-      quickpick.value = value;
-    }
+    quickpick.value = value;
 
     const pickedItem = await new Promise<QuickPickItem | string>(resolve => {
       disposables.push(


### PR DESCRIPTION
Since this option default is changed to false since v0.1.9, I think this is no longer necessary.
